### PR TITLE
Reschedule timer in case of early wakeup even if a valid waker exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Reschedule timer everytime if it gets woken up too early
+
 ## [0.3.1] - 2025-08-06
 
 ### Fixed

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -368,15 +368,8 @@ impl Timer {
             let ticks = Self::ticks(&when);
 
             if let Some(ticks) = ticks {
-                if self
-                    .waker
-                    .as_ref()
-                    .map(|waker| !waker.will_wake(cx.waker()))
-                    .unwrap_or(true)
-                {
-                    self.waker = Some(cx.waker().clone());
-                    embassy_time_driver::schedule_wake(ticks, cx.waker());
-                }
+                self.waker = Some(cx.waker().clone());
+                embassy_time_driver::schedule_wake(ticks, cx.waker());
             } else {
                 self.set_never();
             }


### PR DESCRIPTION
This pull request is my first attempt at fixing #7.

A downside to this way of fixing it is, that polling a future would cause many redundant wakers to get scheduled. But I don't know if there is any way to avoid this with the current API of `embassy-time-driver`.